### PR TITLE
Enhance completion of pattern-triggered snippets.

### DIFF
--- a/lua/cmp_luasnip/init.lua
+++ b/lua/cmp_luasnip/init.lua
@@ -82,7 +82,13 @@ function source:resolve(completion_item, callback)
 end
 
 function source:execute(completion_item, callback)
-	local snip = require("luasnip").snippets[completion_item.data.filetype][completion_item.data.ft_indx]:copy()
+	local snip = require("luasnip").snippets[completion_item.data.filetype][completion_item.data.ft_indx]
+	if snip.regTrig then
+		-- if trigger is a pattern, expand "pattern" instead of actual snippet.
+		snip = snip:get_pattern_expand_helper()
+	else
+		snip = snip:copy()
+	end
 	snip:trigger_expand(Luasnip_current_nodes[vim.api.nvim_get_current_buf()])
 	callback(completion_item)
 end


### PR DESCRIPTION
Right now completion inserts the trigger-string literally and expands, which doesn't really work for snippets that have a pattern as trigger as eg. "%d" doesn't match "%d".
This PR would expand an intermediary snippet so the user can edit the parts of the pattern that aren't just plain text (`"head(%d)" -> head${0:%d}`).
After jumping to the `$0`, the snippet would have to be expanded manually.

What do you think of this behaviour?