### PR TITLE
Add functionality for `hidden`

### DIFF
--- a/lua/cmp_luasnip/init.lua
+++ b/lua/cmp_luasnip/init.lua
@@ -59,15 +59,17 @@ function source:complete(params, callback)
 		local ft_table = require("luasnip").snippets[filetypes[i]]
 		if ft_table then
 			for j, snip in pairs(ft_table) do
-				items[#items + 1] = {
-					word = snip.trigger,
-					label = snip.trigger,
-					kind = cmp.lsp.CompletionItemKind.Snippet,
-					data = {
-						filetype = filetypes[i],
-						ft_indx = j,
-					},
-				}
+				if not snip.hidden then
+					items[#items + 1] = {
+						word = snip.trigger,
+						label = snip.trigger,
+						kind = cmp.lsp.CompletionItemKind.Snippet,
+						data = {
+							filetype = filetypes[i],
+							ft_indx = j,
+						},
+					}
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Luasnip only implements a key to mark a snippet as hidden, the actual filtering has to happen in the snippet engines.

(If there are more keys that manipulate the availability of snippets/more completion engines, there would be a case to constructing the list of "completion-snippets" in luasnip, but that isn't the case yet, so imo it's okay to just filter here)