### PR TITLE
Check snippet conditions when listing completion candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ use {
 use { 'saadparwaiz1/cmp_luasnip' }
 ```
 
-To enable filtering completion candidates by snippet's `show_condition` 
+To disable filtering completion candidates by snippet's `show_condition`
 use the following options in `sources`:
 
 ```lua
 sources = {
-  { name = 'luasnip', opts = { use_show_condition = true } },
+  { name = 'luasnip', opts = { use_show_condition = false } },
   -- more sources
 },
 ```

--- a/lua/cmp_luasnip/init.lua
+++ b/lua/cmp_luasnip/init.lua
@@ -4,7 +4,7 @@ local util = require("vim.lsp.util")
 local source = {}
 
 local defaults = {
-	use_show_condition = false,
+	use_show_condition = true,
 }
 
 -- the options are being passed via cmp.setup.sources, e.g.


### PR DESCRIPTION
Luasnip allows to specify expansion condition, so one can have a snippet that e.g only expands in strings, like the following one using treesitter:
```lua
function M.inside_ts_node(type, opts)
    opts = opts or {}
    return function()
        local ts_utils = require('nvim-treesitter.ts_utils')
        if not ts_utils then
            return not opts.prefer_outside
        end
        local node = ts_utils.get_node_at_cursor()
        return node and node:type() == type
    end
end

snip(
    { name = 'named regex group', trig = 'ng' },
    fmt('(?P<{}>{})', { i(1, 'name'), i(2, 'contents') }),
    { condition = M.inside_ts_node('string') }
)
```
However nvim-cmp will still list this snippet when the cursor is not in a string.

This PR is an attempt to evaluate the condition when selecting completion candidates.

One problem with this PR is that we are not using `snippet:match()` because it will only match if full snippet trigger has already been inserted, but nvim-cmp should show the snippet candidate even with only partial trigger inserted. Instead of `:match()` the condition function is called directly as `condition(line_to_cursor)`. But the full signature is `condition(line_to_cursor, match, captures)`, so this might break config for some users that have conditions that expect these arguments to be not nil.

Another issue might be worse performance if user conditions are slow to compute, as currently the condition is evaluated only when trying to expand a snippet. 

I am not sure what would be the best solution to these problems. Maybe instead there could be another snippet argument instead of `condition` (e.g. `context(line_to_cursor)`) that would only check if the snippet should be listed at that moment. The `hidden` parameter could accept a function, however it has a different meaning so I don't think that's a good solution.
