### PR TITLE
Use snippet-id instead of index into ft-table.

### DIFF
--- a/lua/cmp_luasnip/init.lua
+++ b/lua/cmp_luasnip/init.lua
@@ -71,7 +71,9 @@ function source:complete(params, callback)
 		if not snip_cache[ft] then
 			-- ft not yet in cache.
 			local ft_items = {}
-			local ft_table = require("luasnip").snippets[ft]
+			local ft_table = require("luasnip").get_snippets(ft, {
+				type = "snippets"
+			})
 			if ft_table then
 				for j, snip in pairs(ft_table) do
 					if not snip.hidden then


### PR DESCRIPTION
As addressed in #33, this doesn't rely on the indices into the ft-table only changing on an `LuasnipSnippetsAdded`.

The `snip.id` is unique for each snippet.