### PR TITLE
Avoid calculating line_to_cursor, take it from params.context

### DIFF
--- a/lua/cmp_luasnip/init.lua
+++ b/lua/cmp_luasnip/init.lua
@@ -96,7 +96,7 @@ function source:complete(params, callback)
 	end
 
 	if params.option.use_show_condition then
-		local line_to_cursor = require('luasnip.util.util').get_current_line_to_cursor()
+		local line_to_cursor = params.context.cursor_before_line
 		items = vim.tbl_filter(function(i)
 			-- check if show_condition exists in case (somehow) user updated cmp_luasnip but not luasnip
 			return not i.data.show_condition or i.data.show_condition(line_to_cursor)


### PR DESCRIPTION
Minor change, but nvim-cmp passes `params.context.cursor_before_line` so we can avoid doubling the work. I guess we can rely on this as it's [documented here](https://github.com/hrsh7th/nvim-cmp/blob/272cbdca3e327bf43e8df85c6f4f00921656c4e4/lua/cmp/context.lua#L18). From my tests this always had the same value as `require('luasnip.util.util').get_current_line_to_cursor()`.