### PR TITLE
feat: sort snippets by effective priority

### DIFF
--- a/lua/cmp_luasnip/init.lua
+++ b/lua/cmp_luasnip/init.lua
@@ -89,6 +89,7 @@ function source:complete(params, callback)
 							label = snip.trigger,
 							kind = cmp.lsp.CompletionItemKind.Snippet,
 							data = {
+								priority = snip.effective_priority or 1000, -- Default priority is used for old luasnip versions
 								filetype = ft,
 								snip_id = snip.id,
 								show_condition = snip.show_condition,
@@ -98,6 +99,9 @@ function source:complete(params, callback)
 					end
 				end
 			end
+			table.sort(ft_items, function(a, b)
+				return a.data.priority > b.data.priority
+			end)
 			snip_cache[ft] = ft_items
 		end
 		vim.list_extend(items, snip_cache[ft])


### PR DESCRIPTION
This change means that snippets will be sorted by their effective priority (unless otherwise sorted by nvim-cmp).
This allows users to easily reorder snippets, for example by sorting
rafamadriz/friendly-snippets after user-defined snippets. (my own
use-case)
for example, the follow code ensures that custom snippets are always
  displayed before friendly-snippets (when otherwise equal):
```lua
return {
    "L3MON4D3/LuaSnip",
    dependencies = { "rafamadriz/friendly-snippets", "nvim-cmp" },
    config = function(opts)
      require("luasnip").setup(opts)
      require("luasnip.loaders.from_vscode").lazy_load({ paths = CUSTOM_SNIPPETS_DIR, default_priority = 2000 })
      require("luasnip.loaders.from_vscode").lazy_load({ paths = FRIENDLY_SNIPPETS_DIR })
    end
}
```
Note that this doesn't affect the order when sorted by nvim-cmp, for
example: input "sysout" will result in "sysout (custom), sysout (friendly), sysoutf (custom)" if sorted using `compare.exact`.

NOTE: This ability was added in https://github.com/L3MON4D3/LuaSnip/issues/1249 and https://github.com/L3MON4D3/LuaSnip/commit/4bf40748f6fe939bdcb69325918535b1c5edea51
