### PR TITLE
fix: prefer luasnip name over regex trigger in completion results

### DIFF
--- a/lua/cmp_luasnip/init.lua
+++ b/lua/cmp_luasnip/init.lua
@@ -85,8 +85,8 @@ function source:complete(params, callback)
 				for j, snip in pairs(tab) do
 					if not snip.hidden then
 						ft_items[#ft_items + 1] = {
-							word = snip.trigger,
-							label = snip.trigger,
+							word = snip.regTrig and snip.name or snip.trigger,
+							label = snip.regTrig and snip.name or snip.trigger,
 							kind = cmp.lsp.CompletionItemKind.Snippet,
 							data = {
 								priority = snip.effective_priority or 1000, -- Default priority is used for old luasnip versions


### PR DESCRIPTION
`blink.cmp` had overcome the similar problems when dealing with regex trigger, [solution](https://github.com/Saghen/blink.cmp/pull/1382) is to prefer luasnip name over trigger when `regTrig = true`, which I find to be reasonable.

Demo:

[Screencast_20250325_163313.webm](https://github.com/user-attachments/assets/53e3906c-eb46-4d03-a7b2-c9ad4314250d)
